### PR TITLE
License label

### DIFF
--- a/MIT_LICENSE
+++ b/MIT_LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (C) 2012 by Tom Benner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Renames the license file to MIT_LICENSE and adds title to the the contents of the file to make clear at a glance that it is MIT licensed.  I couldn't spot any changes to the content of the license.

Obviously feel free to reject this or request that I remove these changes from GitHub as it is your license.
