### PR TITLE
Fixed defect where font-size wouldn't affect elements if font-name is not defined first.

### DIFF
--- a/NUI/Core/Renderers/NUILabelRenderer.m
+++ b/NUI/Core/Renderers/NUILabelRenderer.m
@@ -38,6 +38,10 @@
     if ([NUISettings hasProperty:property withClass:class_name]) {
         label.font = [UIFont fontWithName:[NUISettings get:property withClass:class_name] size:[NUISettings getFloat:size_property withClass:class_name]];
     }
+    else if ([NUISettings getFloat:size_property withClass:class_name]) {   // font-size defined but font-name undefined
+        label.font = [UIFont systemFontOfSize:[NUISettings getFloat:size_property withClass:class_name]];
+        
+    }
     
     property = @"text-alpha";
     if ([NUISettings hasProperty:property withClass:class_name]) {

--- a/NUI/Core/Renderers/NUITextFieldRenderer.m
+++ b/NUI/Core/Renderers/NUITextFieldRenderer.m
@@ -12,9 +12,13 @@
 
 + (void)render:(UITextField*)text_field withClass:(NSString*)class_name
 {
-    // Set font   
+    // Set font
+    NSString *size_property = @"font-size";
     if ([NUISettings hasProperty:@"font-name" withClass:class_name]) {
         [text_field setFont:[UIFont fontWithName:[NUISettings get:@"font-name" withClass:class_name] size:[NUISettings getFloat:@"font-size" withClass:class_name]]];
+    }
+    else if ([NUISettings getFloat:size_property withClass:class_name]) {   // font-size defined but font-name undefined
+        [text_field setFont:[UIFont systemFontOfSize:[NUISettings getFloat:size_property withClass:class_name]]];
     }
     
     // Set border style   


### PR DESCRIPTION
Patch for [Defect #12](https://github.com/tombenner/nui/issues/12)

**Defect Description:**

Font-Size style does not work unless font-name is also set.

**Patch Description:**

Defining "font-size" without defining the attribute "font-name" will result in UI elements using a UIFont object initialised with the method: -systemFontOfSize: instead of ignoring this attribute.
