### PR TITLE
Allow UIColor methods to be used a color names

### DIFF
--- a/NUI/Core/NUIConverter.m
+++ b/NUI/Core/NUIConverter.m
@@ -100,9 +100,13 @@
 
 + (UIColor*)toColor:(NSString*)value
 {
-    
-    if ([value isEqualToString:@"clear"]) {
-        return [UIColor clearColor];
+    // Look at UIColor selectors for a matching selector.
+    // Name matches can take the form of 'colorname' (matching selectors like +redColor with 'red').
+    SEL selector = NSSelectorFromString([NSString stringWithFormat:@"%@Color", value]);
+    if (selector) {
+        if ([[UIColor class] respondsToSelector:selector]) {
+            return [[UIColor class] performSelector:selector];
+        }
     }
     
     NSString *cString = [[value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString];


### PR DESCRIPTION
Now colors from UIColor or catergories of UIColor can be used. Simply take the class method name and remove the Color suffix.

For example, now [UIColor clearColor] can be used as 'clear' in a nss resource, [UIColor redColor] can be used as 'red', ...
