### PR TITLE
Elminate UITextAlignment deprecation warnings.

### DIFF
--- a/NUI/Core/NUIConverter.h
+++ b/NUI/Core/NUIConverter.h
@@ -8,6 +8,18 @@
 
 #import <objc/message.h>
 
+#ifdef __IPHONE_6_0 // iOS6 and later
+#   define kTextAlignment           NSTextAlignment
+#   define kTextAlignmentCenter     NSTextAlignmentCenter
+#   define kTextAlignmentLeft       NSTextAlignmentLeft
+#   define kTextAlignmentRight      NSTextAlignmentRight
+#else // older versions
+#   define kTextAlignment           UITextAlignment
+#   define kTextAlignmentCenter     UITextAlignmentCenter
+#   define kTextAlignmentLeft       UITextAlignmentLeft
+#   define kTextAlignmentRight      UITextAlignmentRight
+#endif
+
 @interface NUIConverter : NSObject
 
 + (BOOL)toBoolean:(id)value;
@@ -20,7 +32,7 @@
 + (UIColor*)toColorFromImageName:(NSString*)value;
 + (UIImage*)toImageFromColorName:(NSString*)value;
 + (UIImage*)toImageFromImageName:(NSString*)value;
-+ (UITextAlignment)toTextAlignment:(NSString*)value;
++ (kTextAlignment)toTextAlignment:(NSString*)value;
 + (UIControlContentHorizontalAlignment)toControlContentHorizontalAlignment:(NSString*)value;
 + (UIControlContentVerticalAlignment)toControlContentVerticalAlignment:(NSString*)value;
 @end

--- a/NUI/Core/NUIConverter.m
+++ b/NUI/Core/NUIConverter.m
@@ -192,14 +192,14 @@
     return [UIImage imageNamed:value];
 }
 
-+ (UITextAlignment)toTextAlignment:(NSString*)value
++ (kTextAlignment)toTextAlignment:(NSString*)value
 {
-    UITextAlignment alignment = UITextAlignmentLeft;
+    kTextAlignment alignment = kTextAlignmentLeft;
     
     if ([value isEqualToString:@"center"]) {
-        alignment =  UITextAlignmentCenter;
+        alignment =   kTextAlignmentCenter;
     } else if ([value isEqualToString:@"right"]) {
-        alignment =  UITextAlignmentRight;
+        alignment =   kTextAlignmentRight;
     }
     
     return alignment;

--- a/NUI/Core/NUISettings.h
+++ b/NUI/Core/NUISettings.h
@@ -31,7 +31,7 @@
 + (UIColor*)getColorFromImage:(NSString*)property withClass:(NSString*)className;
 + (UIImage*)getImage:(NSString*)property withClass:(NSString*)className;
 + (UIImage*)getImageFromColor:(NSString*)property withClass:(NSString*)className;
-+ (UITextAlignment)getTextAlignment:(NSString*)property withClass:(NSString*)className;
++ (kTextAlignment)getTextAlignment:(NSString*)property withClass:(NSString*)className;
 + (UIControlContentHorizontalAlignment)getControlContentHorizontalAlignment:(NSString*)property withClass:(NSString*)className;
 + (UIControlContentVerticalAlignment)getControlContentVerticalAlignment:(NSString*)property withClass:(NSString*)className;
 

--- a/NUI/Core/NUISettings.m
+++ b/NUI/Core/NUISettings.m
@@ -115,7 +115,7 @@ static NUISettings *instance = nil;
     return [NUIConverter toImageFromImageName:[self get:property withClass:className]];
 }
 
-+ (UITextAlignment)getTextAlignment:(NSString*)property withClass:(NSString*)className
++ (kTextAlignment)getTextAlignment:(NSString*)property withClass:(NSString*)className
 {
     return [NUIConverter toTextAlignment:[self get:property withClass:className]];
 }


### PR DESCRIPTION
Use NSTextAlignment on iOS 6 and UITextAlignment on iOS 5. Solution based
on examples from http://stackoverflow.com/q/11920321/79202.
