### PR TITLE
Add assert to ensure a file exists.

### DIFF
--- a/NUI/Core/NUIStyleParser.m
+++ b/NUI/Core/NUIStyleParser.m
@@ -16,6 +16,7 @@
 - (NSMutableDictionary*)getStylesFromFile:(NSString*)fileName
 {
     NSString* path = [[NSBundle mainBundle] pathForResource:fileName ofType:@"nss"];
+    NSAssert1(path != nil, @"File \"%@\" does not exist", fileName);
     NSString* content = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
     return [self consolidateRuleSets:[self getRuleSets:content] withTopLevelDeclarations:[self getTopLevelDeclarations:content]];
 }


### PR DESCRIPTION
Took me a while to track down that I had a typo in my file name, because the
exception thrown was from NSRegularExpression. So add an `NSAssert()` to save
other future developers from themselves.
