### PR TITLE
BarButton items not rendered at Retina resolution

### DIFF
--- a/NUI/Core/NUIGraphics.m
+++ b/NUI/Core/NUIGraphics.m
@@ -100,7 +100,10 @@
 
 + (UIImage*)caLayerToUIImage:(CALayer*)layer
 {
-    UIGraphicsBeginImageContext(layer.frame.size);
+    UIScreen *screen = [UIScreen mainScreen];
+    CGFloat scale = [screen scale];
+    UIGraphicsBeginImageContextWithOptions(layer.frame.size, NO, scale);
+    
     [layer renderInContext:UIGraphicsGetCurrentContext()];
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();


### PR DESCRIPTION
Due to use of UIGraphicsBeginImageContext and not UIGraphicsBeginImageContextWithOptions, BarButton borders etc were rendered at non-retina resolution, so the edges looked all blurry. Fixed with this pull request.

Before:
![Screen Shot 2013-01-09 at 12 17 13](https://f.cloud.github.com/assets/288569/53261/9abe3dec-5a57-11e2-9be2-3c050e00a54d.png)

After:
![Screen Shot 2013-01-09 at 12 20 00](https://f.cloud.github.com/assets/288569/53262/a6ab7c6e-5a57-11e2-8e58-982facaa4107.png)
