### PR TITLE
Fixed a simple bug in [NUIConverter toEdgeInsets:]

### DIFF
--- a/NUI/Core/NUIConverter.m
+++ b/NUI/Core/NUIConverter.m
@@ -72,7 +72,7 @@
             break;
             
         default:
-            edges = [NSArray arrayWithObjects:0, 0, 0, 0, nil];
+            edges = [NSArray arrayWithObjects:@0, @0, @0, @0, nil];
             break;
     }
     // UIEdgeInsetsMake's arguments have a different ordering: top, left, bottom, right


### PR DESCRIPTION
`[NSArray arrayWithObjects:0, 0, 0, 0, nil]` is an empty array and causes an exception a few lines further:

`[edges[0] floatValue],`

I changed it to `[NSArray arrayWithObjects:@0, @0, @0, @0, nil]` as it was intended to be.
