### PR TITLE
Exclude some views or views' hierarchy from being render by NUI

### DIFF
--- a/NUI/Core/NUISettings.h
+++ b/NUI/Core/NUISettings.h
@@ -18,6 +18,7 @@
 
 @property(nonatomic,retain)NSString *autoUpdatePath;
 @property(nonatomic,retain)NSMutableDictionary *styles;
+@property(nonatomic,retain)NSMutableArray *globalExclusions;
 
 + (void)init;
 + (void)initWithStylesheet:(NSString*)name;
@@ -40,5 +41,7 @@
 + (kTextAlignment)getTextAlignment:(NSString*)property withClass:(NSString*)className;
 + (UIControlContentHorizontalAlignment)getControlContentHorizontalAlignment:(NSString*)property withClass:(NSString*)className;
 + (UIControlContentVerticalAlignment)getControlContentVerticalAlignment:(NSString*)property withClass:(NSString*)className;
++ (NSMutableArray*)getGlobalExclusions;
++ (void)setGlobalExclusions:(NSArray*)globalExclusions;
 
 @end

--- a/NUI/Core/NUISettings.m
+++ b/NUI/Core/NUISettings.m
@@ -180,4 +180,16 @@ static NUISettings *instance = nil;
     return instance;
 }
 
++ (void)setGlobalExclusions:(NSArray *)array
+{
+    instance = [self getInstance];
+    instance.globalExclusions = [array mutableCopy];
+}
+
++ (NSMutableArray*)getGlobalExclusions
+{
+    instance = [self getInstance];
+    return instance.globalExclusions;
+}
+
 @end

--- a/NUI/UI/UIView+NUI.m
+++ b/NUI/UI/UIView+NUI.m
@@ -42,25 +42,34 @@
     [self override_didMoveToWindow];
 }
 
-- (void)setNuiClass:(NSString*)value {
-    // Set class to none if any view superviews is in the exclude
-    NSArray *excludeSubviews = [[NUISettings get:@"exclude-subviews" withClass:value] componentsSeparatedByString:@","];
-    if(excludeSubviews.count){
-        UIView *superView = self;
-        while (superView != nil) {
-            if ([excludeSubviews containsObject:NSStringFromClass([superView class])]) {
+- (void)setNuiClass:(NSString*)value
+{
+    if(![value isEqualToString:@"none"]) {
+        // Set class to none if view is in the exclude
+        NSMutableArray *excludeViews = [NSMutableArray arrayWithArray:[[NUISettings get:@"exclude-views" withClass:value] componentsSeparatedByString:@","]];
+        // add global exclusions to the list
+        [excludeViews addObjectsFromArray:[NUISettings getGlobalExclusions]];
+        if(excludeViews.count){
+            if ([excludeViews containsObject:NSStringFromClass([self class])]) {
                 value = @"none";
-                break;
             }
-            superView = superView.superview;
         }
     }
     
-    // Set class to none if view is in the exclude
-    NSArray *excludeViews = [[NUISettings get:@"exclude-views" withClass:value] componentsSeparatedByString:@","];
-    if(excludeViews.count){
-        if ([excludeViews containsObject:NSStringFromClass([self class])]) {
-            value = @"none";
+    if(![value isEqualToString:@"none"]) {
+        // Set class to none if any view superviews is in the exclude
+        NSMutableArray *excludeSubviews = [NSMutableArray arrayWithArray:[[NUISettings get:@"exclude-subviews" withClass:value] componentsSeparatedByString:@","]];
+        // add global exclusions to the list
+        [excludeSubviews addObjectsFromArray:[NUISettings getGlobalExclusions]];
+        if(excludeSubviews.count){
+            UIView *superView = self;
+            while (superView != nil) {
+                if ([excludeSubviews containsObject:NSStringFromClass([superView class])]) {
+                    value = @"none";
+                    break;
+                }
+                superView = superView.superview;
+            }
         }
     }
     


### PR DESCRIPTION
### Context

Ideally NUI CSS Parse will have a better CSS Selector support but until then it's pretty hard to exclude some views from being render. 
You can of course set nuiClass = @"none" but what about view (or subviews) for which you don't have a direct access to (ABPeoplePickerNavigationController, ...).
In my case, if I use one of the default theme and display a person picker, I can't see contacts name.
### Proposed Solution

I've added two new css property (exclude-views and exclude-subviews) which allow to specify some view's class (or view's class subviews) that should never be render by NUI.
I've also added another gloabalExclusions property on NUISettings which will exclude views or subviews of specified class to be render.
### Usage
- New CSS Property

NUIStyle.css

``` css
...
Button {
    background-color: #FFFFFF;
    border-color: @primaryBorderColor;
    border-width: @primaryBorderWidth;
    font-color: @primaryFontColor;
    font-color-highlighted: @secondaryFontColor;
    font-name: @secondaryFontName;
    font-size: 18;
    height: 37;
    corner-radius: 7;
    exclude-views: UIAlertButton;
    exclude-subviews: UITableViewCell,TDBadgedCell,UITextField;
}
...
```
- New Global Exclusions

``` objective-c
int main(int argc, char *argv[])
{
    @autoreleasepool {
#if kNUIEnabled
        [NUISettings initWithStylesheet:@"NUIStyle-1debit"];
        [NUISettings setGlobalExclusions:@[@"ABMemberCell", @"ABMultiCell"]];
#endif
        return UIApplicationMain(argc, argv, nil, NSStringFromClass([HBRAppDelegate class]));
    }
}
```
### Alternative solution

It also possible to only use nuiClass and having a new class call @"noneAll", and do a test on it in applyNui.

``` Objective-C
- (void)applyNUI
{
    // Styling shouldn't be applied to inherited classes
    if ([self class] == [UIView class]) {
        [self initNUI];
        if (![self.nuiClass isEqualToString:@"none"]) {
            BOOL isIncludedInNoneAllView;
            UIView *superview = self;
            while(superview != nil){
                if([superview.nuiClass isEqualToString:@"NoneAll"]){
                    self.nuiClass = @"none";
                }
                superview = superview.superview;
            }

            if (![self.nuiClass isEqualToString:@"none"]) {
                if ([self class] == [UIView class] &&
                    [[self superview] class] != [UINavigationBar class]) {
                    [NUIRenderer renderView:self withClass:self.nuiClass];
                }
            }

        }
    }
    self.nuiIsApplied = [NSNumber numberWithBool:YES];
}
```

It will give less flexibility, be a bit more consuming (will escalate view hierarchy each first time nui is apply to any class).
If you like this solution better, let me know I will submit another pull request.
