### PR TITLE
Fixing crash when using UITableViewCell

### DIFF
--- a/NUI/Core/NUIRenderer.m
+++ b/NUI/Core/NUIRenderer.m
@@ -260,7 +260,7 @@ static NUIRenderer *instance = nil;
 
 + (void)registerObject:(NSObject*)object
 {
-    if ([NUISettings autoUpdateIsEnabled]) {
+    if ([NUISettings autoUpdateIsEnabled] && object != nil) {
         NSString *hash = [NSString stringWithFormat:@"%d", object.hash];
         NUIRenderer *instance = [self getInstance];
         if (![instance.renderedObjectIdentifiers containsObject:hash]) {

--- a/NUI/Core/Renderers/NUITableViewCellRenderer.m
+++ b/NUI/Core/Renderers/NUITableViewCellRenderer.m
@@ -16,12 +16,17 @@
     
     // Set the labels' background colors to clearColor by default, so they don't show a white
     // background on top of the cell background color
-    [cell.textLabel setBackgroundColor:[UIColor clearColor]];
-    [cell.detailTextLabel setBackgroundColor:[UIColor clearColor]];
+    if (cell.textLabel != nil) {
+        [cell.textLabel setBackgroundColor:[UIColor clearColor]];
+        // Set Font
+        [NUIRenderer renderLabel:cell.textLabel withClass:className];
+    }
     
-    // Set fonts
-    [NUIRenderer renderLabel:cell.textLabel withClass:className];
-    [NUIRenderer renderLabel:cell.detailTextLabel withClass:className withSuffix:@"Detail"];
+    if (cell.detailTextLabel != nil) {
+        [cell.detailTextLabel setBackgroundColor:[UIColor clearColor]];
+        // Set font
+        [NUIRenderer renderLabel:cell.detailTextLabel withClass:className withSuffix:@"Detail"];
+    }
     
 }
 


### PR DESCRIPTION
We have a custom UITableViewCell that doesn't use the textLabel or the detailTextLabel. NUI crashes when it tries to register with autoupdate. 

This fix does a check to see if the labels are nil before setting them, and also fixes the register object method to check for nil before registering.
