### PR TITLE
Setting nuiClass on a view should force NUI to be used, regardless of subclassing status

### DIFF
--- a/NUI/UI/UIControl+NUI.m
+++ b/NUI/UI/UIControl+NUI.m
@@ -19,8 +19,9 @@
 
 - (void)applyNUI
 {
-    // Styling shouldn't be applied to inherited classes
-    if ([self class] == [UIControl class]) {
+    // Styling shouldn't be applied to inherited classes, unless nuiClass is
+    // explictly set
+    if ([self class] == [UIControl class] || self.nuiClass) {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             [NUIRenderer renderView:self withClass:self.nuiClass];

--- a/NUI/UI/UILabel+NUI.m
+++ b/NUI/UI/UILabel+NUI.m
@@ -20,9 +20,9 @@
 - (void)applyNUI
 {
     // Styling shouldn't be applied to inherited classes or to labels within other views
-    // (e.g. UITableViewCellContentView)
-    if ([self class] == [UILabel class] &&
-        [[self superview] class] == [UIView class]) {
+    // (e.g. UITableViewCellContentView), unless nuiClass is explictly set
+    if (([self class] == [UILabel class] &&
+        [[self superview] class] == [UIView class]) || self.nuiClass) {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             [NUIRenderer renderLabel:self withClass:self.nuiClass];

--- a/NUI/UI/UISlider+NUI.m
+++ b/NUI/UI/UISlider+NUI.m
@@ -19,8 +19,9 @@
 
 - (void)applyNUI
 {
-    // Styling shouldn't be applied to inherited classes
-    if ([self class] == [UISlider class]) {
+    // Styling shouldn't be applied to inherited classes, unless nuiClass is
+    // explictly set
+    if ([self class] == [UISlider class] || self.nuiClass) {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             if ([self class] == [UISlider class]) {

--- a/NUI/UI/UISwitch+NUI.m
+++ b/NUI/UI/UISwitch+NUI.m
@@ -19,8 +19,9 @@
 
 - (void)applyNUI
 {
-    // Styling shouldn't be applied to inherited classes
-    if ([self class] == [UISwitch class]) {
+    // Styling shouldn't be applied to inherited classes, unless nuiClass is
+    // explictly set
+    if ([self class] == [UISwitch class] || self.nuiClass) {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             if ([self class] == [UISwitch class]) {

--- a/NUI/UI/UIView+NUI.m
+++ b/NUI/UI/UIView+NUI.m
@@ -21,8 +21,9 @@
 
 - (void)applyNUI
 {
-    // Styling shouldn't be applied to inherited classes
-    if ([self class] == [UIView class]) {
+    // Styling shouldn't be applied to inherited classes, unless nuiClass is
+    // explictly set
+    if ([self class] == [UIView class] || self.nuiClass) {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             if ([self class] == [UIView class] &&


### PR DESCRIPTION
The use case that led to this change is the following:

I have a custom UIView subclass, within that are a number of UILabels where I'd like to use NUI. Previously, since they were embedded in a UIView subclass, NUI would skip over them and not apply a style. This change will now let them use NUI, if a nuiClass is explicitly set.

This change has also been applied to similar checks in UIView, UIControl, UISlider, UISwitch (+NUI.m)
