### PR TITLE
Support for Width and Height on UIView, UILabel, UIButton and UITextField

### DIFF
--- a/NUI/Core/Renderers/NUIButtonRenderer.m
+++ b/NUI/Core/Renderers/NUIButtonRenderer.m
@@ -22,15 +22,7 @@
             [button.layer.sublayers[1] setOpacity:0.0f];
         }
     }
-    
-    // Set height
-    if ([NUISettings hasProperty:@"height" withClass:className]) {
-        CGRect frame = button.frame;
-        CGSize originalSize = frame.size;
-        frame.size = CGSizeMake(originalSize.width, [NUISettings getFloat:@"height" withClass:className]);
-        button.frame = frame;
-    }
-    
+
     // Set padding
     if ([NUISettings hasProperty:@"padding" withClass:className]) {
         [button setTitleEdgeInsets:[NUISettings getEdgeInsets:@"padding" withClass:className]];
@@ -128,7 +120,8 @@
             layer.cornerRadius = r;
         }
     }
-    
+
+    [NUIViewRenderer renderSize:button withClass:className];
     [NUIViewRenderer renderShadow:button withClass:className];
 }
 

--- a/NUI/Core/Renderers/NUILabelRenderer.m
+++ b/NUI/Core/Renderers/NUILabelRenderer.m
@@ -28,7 +28,8 @@
         // UILabels created programmatically have a white background by default
         label.backgroundColor = [UIColor clearColor];
     }
-    
+
+    [NUIViewRenderer renderSize:label withClass:className];
     [NUIViewRenderer renderBorder:label withClass:className];
     [NUIViewRenderer renderShadow:label withClass:className];
     [self renderText:label withClass:className];

--- a/NUI/Core/Renderers/NUITextFieldRenderer.m
+++ b/NUI/Core/Renderers/NUITextFieldRenderer.m
@@ -50,20 +50,13 @@
     if ([NUISettings hasProperty:@"vertical-align" withClass:className]) {
         [textField setContentVerticalAlignment:[NUISettings getControlContentVerticalAlignment:@"vertical-align" withClass:className]];
     }
-    
-    // Set height
-    if ([NUISettings hasProperty:@"height" withClass:className]) {
-        CGRect buttonFrame = textField.frame;
-        CGSize originalSize = buttonFrame.size;
-        buttonFrame.size = CGSizeMake(originalSize.width, [NUISettings getFloat:@"height" withClass: className]);
-        textField.frame = buttonFrame;
-    }
-    
+
     // Set border style
     if ([NUISettings hasProperty:@"border-style" withClass:className]) {
         [textField setBorderStyle:[NUISettings getBorderStyle:@"border-style" withClass:className]];
     }
-    
+
+    [NUIViewRenderer renderSize:textField withClass:className];
     [NUIViewRenderer renderBorder:textField withClass:className];
     [NUIViewRenderer renderShadow:textField withClass:className];
 }

--- a/NUI/Core/Renderers/NUIViewRenderer.h
+++ b/NUI/Core/Renderers/NUIViewRenderer.h
@@ -15,5 +15,6 @@
 + (void)render:(UIView*)view withClass:(NSString*)className;
 + (void)renderBorder:(UIView*)view withClass:(NSString*)className;
 + (void)renderShadow:(UIView*)view withClass:(NSString*)className;
++ (void)renderSize:(UIView*)view withClass:(NSString*)className;
 
 @end

--- a/NUI/Core/Renderers/NUIViewRenderer.m
+++ b/NUI/Core/Renderers/NUIViewRenderer.m
@@ -17,7 +17,8 @@
     } else if ([NUISettings hasProperty:@"background-color" withClass:className]) {
         [view setBackgroundColor: [NUISettings getColor:@"background-color" withClass: className]];
     }
-    
+
+    [self renderSize:view withClass:className];
     [self renderBorder:view withClass:className];
     [self renderShadow:view withClass:className];
 }
@@ -57,6 +58,23 @@
     
     if ([NUISettings hasProperty:@"shadow-opacity" withClass:className]) {
         [layer setShadowOpacity:[NUISettings getFloat:@"shadow-opacity" withClass:className]];
+    }
+}
+
++ (void)renderSize:(UIView*)view withClass:(NSString*)className
+{
+    CGFloat height = view.frame.size.height;
+    if ([NUISettings hasProperty:@"height" withClass:className]) {
+        height = [NUISettings getFloat:@"height" withClass:className];
+    }
+    
+    CGFloat width = view.frame.size.width;
+    if ([NUISettings hasProperty:@"width" withClass:className]) {
+        width = [NUISettings getFloat:@"width" withClass:className];
+    }
+
+    if (height != view.frame.size.height || width != view.frame.size.width) {
+        view.frame = CGRectMake(view.frame.origin.x, view.frame.origin.y, width, height);
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Below are all of the currently available style classes, their corresponding UI c
 * text-shadow-color-selected *(Color)*
 * text-shadow-offset *(Offset)*
 * title-insets *(Box)*
+* width *(Number)*
 
 #### Control
 
@@ -236,6 +237,7 @@ Below are all of the currently available style classes, their corresponding UI c
 * font-color-highlighted *(Color)*
 * font-name *(FontName)*
 * font-size *(Number)*
+* height *(Number)*
 * shadow-color *(Color)*
 * shadow-offset *(Offset)*
 * shadow-opacity *(Number)*
@@ -245,6 +247,7 @@ Below are all of the currently available style classes, their corresponding UI c
 * text-auto-fit *(Boolean)*
 * text-shadow-color *(Color)*
 * text-shadow-offset *(Offset)*
+* width *(Number)*
 
 #### NavigationBar
 
@@ -415,6 +418,7 @@ The detail label of a *UITableViewCell*
 * shadow-opacity *(Number)*
 * shadow-radius *(Number)*
 * vertical-align *(VerticalAlign)*
+* width *(Number)*
 
 #### View
 
@@ -425,10 +429,12 @@ The detail label of a *UITableViewCell*
 * border-color *(Color)*
 * border-width *(Number)*
 * corner-radius *(Number)*
+* height *(Number)*
 * shadow-color *(Color)*
 * shadow-offset *(Offset)*
 * shadow-opacity *(Number)*
 * shadow-radius *(Number)*
+* width *(Number)*
 
 #### Window
 


### PR DESCRIPTION
This change adds support for height and width to UIView, UILabel, UITextField and UIButton. For UITextField and UIButton, which already supported height, I've refactored these to use UIView's renderer.

I tested all these attributes manually using a local copy of the demo application (not pushed).
