### PR TITLE
Make UISwitch and UISlider render subclasses correctly

### DIFF
--- a/NUI/UI/UISlider+NUI.m
+++ b/NUI/UI/UISlider+NUI.m
@@ -24,9 +24,7 @@
     if ([self class] == [UISlider class] || self.nuiClass) {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
-            if ([self class] == [UISlider class]) {
-                [NUIRenderer renderSlider:self withClass:self.nuiClass];
-            }
+            [NUIRenderer renderSlider:self withClass:self.nuiClass];
         }
     }
     self.nuiIsApplied = [NSNumber numberWithBool:YES];

--- a/NUI/UI/UISwitch+NUI.m
+++ b/NUI/UI/UISwitch+NUI.m
@@ -24,9 +24,7 @@
     if ([self class] == [UISwitch class] || self.nuiClass) {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
-            if ([self class] == [UISwitch class]) {
-                [NUIRenderer renderSwitch:self withClass:self.nuiClass];
-            }
+            [NUIRenderer renderSwitch:self withClass:self.nuiClass];
         }
     }
     self.nuiIsApplied = [NSNumber numberWithBool:YES];


### PR DESCRIPTION
I found two more classes that were not rendering the subclasses even when the nuiClass was set. I've checked the rest of the classes and these seem to be the last two.
