### PR TITLE
Update NUI.podspec

### DIFF
--- a/NUI.podspec
+++ b/NUI.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
   s.author       = { "Tom Benner" => "tombenner@gmail.com" }
   s.source       = { :git => "https://github.com/tombenner/nui.git", :tag => "v0.2.8" }
-  s.platform     = :ios, '6.0'
+  s.platform     = :ios, '5.1'
 
   s.source_files = 'NUI', 'NUI/**/*.{h,m}'
   s.resources    = "NUI/Resources/*.png", "NUI/**/*.nss"


### PR DESCRIPTION
NUI compiles properly and runs when the deployment target is set to 5.1. Any reason why the podspec is locked to 6.0?
