### PR TITLE
Added button that allows people get built application in their devices from browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@ NUI
 ===
 Style iOS apps with a style sheet, similar to CSS
 
+<!-- MacBuildServer Install Button -->
+<div class="macbuildserver-block">
+    <a class="macbuildserver-button" href="http://macbuildserver.com/project/github/build/?xcode_project=Demo%2FNUIDemo.xcodeproj&amp;target=NUIDemo&amp;repo_url=git%3A%2F%2Fgithub.com%2Ftombenner%2Fnui.git&amp;build_conf=Release" target="_blank"><img src="http://com.macbuildserver.github.s3-website-us-east-1.amazonaws.com/button_up.png"/></a><br/><sup><a href="http://macbuildserver.com/github/opensource/" target="_blank">by MacBuildServer</a></sup>
+</div>
+<!-- MacBuildServer Install Button -->
+
 Description
 -----------
 NUI is a drop-in UI kit for iOS that lets you style UI elements using a style sheet, similar to CSS. It lets you style an entire app in minutes.


### PR DESCRIPTION
Hey,

I've added 'Install app' button into your README file. Anyone could try your sample application right in browser. Look how it's working!

To learn more, please look at: http://macbuildserver.com/github/opensource/
