### PR TITLE
Prevent clearing label background when it's set.

### DIFF
--- a/NUI/Core/Renderers/NUILabelRenderer.m
+++ b/NUI/Core/Renderers/NUILabelRenderer.m
@@ -26,7 +26,9 @@
         label.backgroundColor = [NUISettings getColor:@"background-color" withClass:className];
     } else {
         // UILabels created programmatically have a white background by default
-        label.backgroundColor = [UIColor clearColor];
+        if (!label.backgroundColor || [label.backgroundColor isEqual:[UIColor whiteColor]]) {
+            label.backgroundColor = [UIColor clearColor];
+        }
     }
 
     [NUIViewRenderer renderSize:label withClass:className];


### PR DESCRIPTION
I.e. prevent clearing `label.backgroundColor` when it's neither unset nor white.

NUI shouldn't override this unless it's explicitly set in the `.nss` file. The issue struck me when I changed the background colour in Interface Builder.
