### PR TITLE
support for UITableView 'separatorColor' property

### DIFF
--- a/NUI/Core/Renderers/NUITableViewRenderer.m
+++ b/NUI/Core/Renderers/NUITableViewRenderer.m
@@ -36,7 +36,12 @@
                                   frame:tableView.bounds];
         tableView.backgroundView = [[UIImageView alloc] initWithImage:gradientImage];
     }
-    
+
+    // Set separator color
+    if ([NUISettings hasProperty:@"separator-color" withClass:className]) {
+        tableView.separatorColor = [NUISettings getColor:@"separator-color" withClass:className];
+        tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;
+    }
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ See SegmentedControl
 
 * background-color *(Color)*
 * background-color-top/background-color-bottom *(Gradient)*
+* separator-color *(Color)*
 
 #### TableCell
 


### PR DESCRIPTION
This sets the 'separatorColor' property in a UITableView. It's most useful for affecting the cell border colour in a grouped table.
