### PR TITLE
Add NUI_customRender in a protocol that classes can implement

### DIFF
--- a/NUI/Core/NUIRenderer.h
+++ b/NUI/Core/NUIRenderer.h
@@ -30,6 +30,11 @@
 #import "NUIWindowRenderer.h"
 #import "UIView+NUI.h"
 
+@protocol NUIRenderer <NSObject>
+@optional
+- (void)NUI_customRender;
+@end
+
 @interface NUIRenderer : NSObject {
     NSMutableArray *renderedObjects;
     NSMutableArray *renderedObjectIdentifiers;

--- a/NUI/Core/NUIRenderer.m
+++ b/NUI/Core/NUIRenderer.m
@@ -366,6 +366,9 @@ static NUIRenderer *instance = nil;
     for (int i = 0; i < [instance.renderedObjects count]; i++) {
         UIView *object = [instance.renderedObjects objectAtIndex:i];
         [NUIRenderer render:object];
+        if ([object respondsToSelector:@selector(NUI_customRender)]) {
+            [object performSelector:@selector(NUI_customRender)];
+        }
     }
     [CATransaction flush];
 }

--- a/NUI/UI/UIBarButtonItem+NUI.m
+++ b/NUI/UI/UIBarButtonItem+NUI.m
@@ -33,6 +33,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_awakeFromNib];
 }
@@ -41,6 +45,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UIButton+NUI.m
+++ b/NUI/UI/UIButton+NUI.m
@@ -51,6 +51,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UIControl+NUI.m
+++ b/NUI/UI/UIControl+NUI.m
@@ -34,6 +34,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UILabel+NUI.m
+++ b/NUI/UI/UILabel+NUI.m
@@ -35,6 +35,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UINavigationBar+NUI.m
+++ b/NUI/UI/UINavigationBar+NUI.m
@@ -39,6 +39,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UINavigationItem+NUI.m
+++ b/NUI/UI/UINavigationItem+NUI.m
@@ -32,6 +32,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UIProgressView+NUI.m
+++ b/NUI/UI/UIProgressView+NUI.m
@@ -33,6 +33,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UISearchBar+NUI.m
+++ b/NUI/UI/UISearchBar+NUI.m
@@ -30,6 +30,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UISegmentedControl+NUI.m
+++ b/NUI/UI/UISegmentedControl+NUI.m
@@ -30,6 +30,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UISlider+NUI.m
+++ b/NUI/UI/UISlider+NUI.m
@@ -34,6 +34,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UISwitch+NUI.m
+++ b/NUI/UI/UISwitch+NUI.m
@@ -34,6 +34,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UITabBar+NUI.m
+++ b/NUI/UI/UITabBar+NUI.m
@@ -31,6 +31,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UITableViewCell+NUI.m
+++ b/NUI/UI/UITableViewCell+NUI.m
@@ -31,6 +31,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UITextField+NUI.m
+++ b/NUI/UI/UITextField+NUI.m
@@ -30,6 +30,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UIToolbar+NUI.m
+++ b/NUI/UI/UIToolbar+NUI.m
@@ -34,6 +34,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UIView+NUI.m
+++ b/NUI/UI/UIView+NUI.m
@@ -35,6 +35,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_didMoveToWindow];
 }

--- a/NUI/UI/UIWindow+NUI.m
+++ b/NUI/UI/UIWindow+NUI.m
@@ -29,6 +29,10 @@
 {
     if (!self.nuiIsApplied) {
         [self applyNUI];
+        
+        if ([self respondsToSelector:@selector(NUI_customRender)]) {
+            [self performSelector:@selector(NUI_customRender)];
+        }
     }
     [self override_becomeKeyWindow];
 }


### PR DESCRIPTION
Quick and dirty solution, I'm pretty sure there is a better way to add the possibility to extend NUI to support custom view classes.

This is called when the NUI theme is applied and let classes apply custom styling in reaction to the NUI style or by reading custom extended properties in them.