### PR TITLE
Image from gradient colors for UIButton normal and highlighted states.

### DIFF
--- a/NUI/Core/NUIConverter.m
+++ b/NUI/Core/NUIConverter.m
@@ -128,6 +128,8 @@
                                  componentsJoinedByString:@""]
                                  uppercaseString];
     
+    NSArray *rgbaAlphaStrings = [NUIConverter getCapturedStrings:cString
+                                                     withPattern:@"(RGBA)\\((?:0X|#)([0-9A-F]{6}),(\\d{1,3}|[0-9.]+)\\)"];
     NSArray *hexStrings = [NUIConverter getCapturedStrings:cString
                                                withPattern:@"(?:0X|#)([0-9A-F]{6})"];
     NSArray *csStrings = [NUIConverter getCapturedStrings:cString
@@ -135,7 +137,17 @@
     
     UIColor *color = nil;
     
-    if (hexStrings) {        
+    if (rgbaAlphaStrings) {
+        CGFloat a = [NUIConverter parseColorComponent:[rgbaAlphaStrings objectAtIndex:3]];
+        
+        unsigned int c;
+        [[NSScanner scannerWithString:[rgbaAlphaStrings objectAtIndex:2]] scanHexInt:&c];
+        color = [UIColor colorWithRed:(float)((c >> 16) & 0xFF) / 255.0f
+                                green:(float)((c >>  8) & 0xFF) / 255.0f
+                                 blue:(float)((c >>  0) & 0xFF) / 255.0f
+                                alpha:a];
+    }
+    else if (hexStrings) {
         unsigned int c;
         [[NSScanner scannerWithString:[hexStrings objectAtIndex:1]] scanHexInt:&c];
         color = [UIColor colorWithRed:(float)((c >> 16) & 0xFF) / 255.0f

--- a/NUI/Core/NUISettings.h
+++ b/NUI/Core/NUISettings.h
@@ -39,6 +39,7 @@
 + (UIColor*)getColorFromImage:(NSString*)property withClass:(NSString*)className;
 + (UIImage*)getImage:(NSString*)property withClass:(NSString*)className;
 + (UIImage*)getImageFromColor:(NSString*)property withClass:(NSString*)className;
++ (UIImage*)getImageFromGradientColors:(NSArray*)colors size:(CGSize)size;
 + (kTextAlignment)getTextAlignment:(NSString*)property withClass:(NSString*)className;
 + (UIControlContentHorizontalAlignment)getControlContentHorizontalAlignment:(NSString*)property withClass:(NSString*)className;
 + (UIControlContentVerticalAlignment)getControlContentVerticalAlignment:(NSString*)property withClass:(NSString*)className;

--- a/NUI/Core/NUISettings.m
+++ b/NUI/Core/NUISettings.m
@@ -141,6 +141,28 @@ static NUISettings *instance = nil;
     return [NUIConverter toImageFromColorName:[self get:property withClass:className]];
 }
 
++ (UIImage*)getImageFromGradientColors:(NSArray*)colors size:(CGSize)size
+{
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGFloat locations[2] = {0.0 ,1.0};
+    CFArrayRef cgColors = (__bridge CFArrayRef) @[(id)[colors[0] CGColor], (id)[colors[1] CGColor]];
+    
+    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
+    CGGradientRef gradient = CGGradientCreateWithColors(colorspace, cgColors, locations);
+    
+    CGContextDrawLinearGradient(context, gradient, CGPointMake(0.5, 0.0), CGPointMake(0.5, 100.0), kCGGradientDrawsAfterEndLocation);
+    
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    
+    UIGraphicsEndImageContext();
+    
+    CGGradientRelease(gradient);
+    CGColorSpaceRelease(colorspace);
+    return image;
+}
+
 + (UIImage*)getImage:(NSString*)property withClass:(NSString*)className
 {
     UIImage *image = [NUIConverter toImageFromImageName:[self get:property withClass:className]];

--- a/NUI/Core/Renderers/NUIButtonRenderer.m
+++ b/NUI/Core/Renderers/NUIButtonRenderer.m
@@ -45,15 +45,34 @@
     
     // Set background gradient
     if ([NUISettings hasProperty:@"background-color-top" withClass:className]) {
-        CAGradientLayer *gradientLayer = [NUIGraphics
-                                          gradientLayerWithTop:[NUISettings getColor:@"background-color-top" withClass:className]
-                                          bottom:[NUISettings getColor:@"background-color-bottom" withClass:className]
-                                          frame:button.bounds];
-        int backgroundLayerIndex = [button.layer.sublayers count] == 1 ? 0 : 1;
-        if (button.nuiIsApplied) {
-            [[button.layer.sublayers objectAtIndex:backgroundLayerIndex] removeFromSuperlayer];
+        UIColor *topColor = [NUISettings getColor:@"background-color-top" withClass:className];
+        
+        if ([NUISettings hasProperty:@"background-color-bottom" withClass:className]) {
+            UIColor *bottomColor = [NUISettings getColor:@"background-color-bottom" withClass:className];
+            
+            UIImage *backgroundImage = [NUISettings getImageFromGradientColors:@[topColor, bottomColor] size:button.bounds.size];
+            
+            [button setBackgroundImage:backgroundImage
+                              forState:UIControlStateNormal];
         }
-        [button.layer insertSublayer:gradientLayer atIndex:backgroundLayerIndex];
+        
+    }
+    
+    // Set background highlighted gradient
+    if ([NUISettings hasProperty:@"background-color-highlighted-top" withClass:className]) {
+        UIColor *topColor = [NUISettings getColor:@"background-color-highlighted-top" withClass:className];
+        
+        if ([NUISettings hasProperty:@"background-color-highlighted-bottom" withClass:className]) {
+            UIColor *bottomColor = [NUISettings getColor:@"background-color-highlighted-bottom" withClass:className];
+            
+            UIImage *backgroundImage = [NUISettings getImageFromGradientColors:@[topColor, bottomColor] size:button.bounds.size];
+            
+            [button setBackgroundImage:backgroundImage
+                              forState:UIControlStateHighlighted];
+            [button setBackgroundImage:backgroundImage
+                              forState:UIControlStateHighlighted|UIControlStateSelected];
+        }
+        
     }
     
     // Set background image


### PR DESCRIPTION
Added a new function in NUISettings that returns an image from gradient colors and size.
- (UIImage_)getImageFromGradientColors:(NSArray_)colors size:(CGSize)size;

Updated NUIButtonRenderer to utilize this new mthod for normal and highlighted state gradient backgrounds.
