### PR TITLE
Replaced explicit class comparisons with 'isMemberOfClass'

### DIFF
--- a/NUI/UI/UIControl+NUI.m
+++ b/NUI/UI/UIControl+NUI.m
@@ -21,7 +21,8 @@
 {
     // Styling shouldn't be applied to inherited classes, unless nuiClass is
     // explictly set
-    if ([self class] == [UIControl class] || self.nuiClass) {
+    if ([self isMemberOfClass:[UIControl class]] ||
+        self.nuiClass) {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             [NUIRenderer renderView:self withClass:self.nuiClass];

--- a/NUI/UI/UILabel+NUI.m
+++ b/NUI/UI/UILabel+NUI.m
@@ -21,8 +21,10 @@
 {
     // Styling shouldn't be applied to inherited classes or to labels within other views
     // (e.g. UITableViewCellContentView), unless nuiClass is explictly set
-    if (([self class] == [UILabel class] &&
-        [[self superview] class] == [UIView class]) || self.nuiClass) {
+    if (([self isMemberOfClass:[UILabel class]] &&
+        [[self superview] isMemberOfClass:[UIView class]]) ||
+        self.nuiClass)
+    {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             [NUIRenderer renderLabel:self withClass:self.nuiClass];

--- a/NUI/UI/UIProgressView+NUI.m
+++ b/NUI/UI/UIProgressView+NUI.m
@@ -19,7 +19,8 @@
 
 - (void)applyNUI
 {
-    if ([self class] == [UIProgressView class] || self.nuiClass) {
+    if ([self isMemberOfClass:[UIProgressView class]] || self.nuiClass) {
+        
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             [NUIRenderer renderProgressView:self withClass:self.nuiClass];

--- a/NUI/UI/UISlider+NUI.m
+++ b/NUI/UI/UISlider+NUI.m
@@ -21,7 +21,8 @@
 {
     // Styling shouldn't be applied to inherited classes, unless nuiClass is
     // explictly set
-    if ([self class] == [UISlider class] || self.nuiClass) {
+    if ([self isMemberOfClass:[UISlider class]] || self.nuiClass) {
+        
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             [NUIRenderer renderSlider:self withClass:self.nuiClass];

--- a/NUI/UI/UISwitch+NUI.m
+++ b/NUI/UI/UISwitch+NUI.m
@@ -21,7 +21,7 @@
 {
     // Styling shouldn't be applied to inherited classes, unless nuiClass is
     // explictly set
-    if ([self class] == [UISwitch class] || self.nuiClass) {
+    if ([self isMemberOfClass:[UISwitch class]] || self.nuiClass) {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             [NUIRenderer renderSwitch:self withClass:self.nuiClass];

--- a/NUI/UI/UIView+NUI.m
+++ b/NUI/UI/UIView+NUI.m
@@ -22,7 +22,9 @@
 - (void)applyNUI
 {
     // Styling shouldn't be applied to inherited classes, unless nuiClass is explictly set
-    if (([self class] == [UIView class] && [[self superview] class] != [UINavigationBar class]) || self.nuiClass) {
+    if (([self isMemberOfClass:[UIView class]] && ![[self superview] isMemberOfClass:[UINavigationBar class]]) ||
+        self.nuiClass)
+    {
         [self initNUI];
         if (![self.nuiClass isEqualToString:@"none"]) {
             [NUIRenderer renderView:self withClass:self.nuiClass];


### PR DESCRIPTION
Although the current comparison of classes works. I believe it is clearer and safer to use the method "-isMemberOfClass".
