### PR TITLE
Blending optimization for 'imageFromColorName conversion

### DIFF
--- a/NUI/Core/NUIConverter.m
+++ b/NUI/Core/NUIConverter.m
@@ -190,8 +190,11 @@
 
 + (UIImage*)toImageFromColorName:(NSString*)value {
     UIColor* color = [self toColor:value];
+    CGFloat alphaChannel;
+    [color getRed:NULL green:NULL blue:NULL alpha:&alphaChannel];
+    BOOL opaqueImage = (alphaChannel == 1.0);
     CGRect rect = CGRectMake(0, 0, 1, 1);
-    UIGraphicsBeginImageContextWithOptions(rect.size, NO, 0);
+    UIGraphicsBeginImageContextWithOptions(rect.size, opaqueImage, 0);
     [color setFill];
     UIRectFill(rect);
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();


### PR DESCRIPTION
UITableViewCells (a UIVIew that requires critical performance) background color included transparency even when their color had an alpha channel of 1.0. 

This has been to corrected.
