### PR TITLE
Fixing an issue that causes a crash when an observer messages an object ...

### DIFF
--- a/NUI/Core/NUISwizzler.m
+++ b/NUI/Core/NUISwizzler.m
@@ -37,6 +37,11 @@
     [self swizzle:[UITextField class] methodName:@"textRectForBounds:"];
     [self swizzle:[UITextField class] methodName:@"editingRectForBounds:"];
     [self swizzle:[UIWindow class] methodName:@"becomeKeyWindow"];
+    
+    [self swizzleDealloc:[UINavigationBar class]];
+    [self swizzleDealloc:[UITabBar class]];
+    [self swizzleDealloc:[UITableViewCell class]];
+    [self swizzleDealloc:[UITableView class]];
 }
 
 - (void)swizzleAwakeFromNib:(Class)class

--- a/NUI/UI/UITableView+NUI.m
+++ b/NUI/UI/UITableView+NUI.m
@@ -32,4 +32,9 @@
     [NUIRenderer performSelector:@selector(sizeDidChangeForTableView:) withObject:self afterDelay:0];
 }
 
+- (void)override_dealloc {
+    [NUIRenderer removeOrientationDidChangeObserver:self];
+    [self override_dealloc];
+}
+
 @end


### PR DESCRIPTION
...which has been deallocated.

This issue is typically easily reproducible on iOS 7.
