### PR TITLE
Prevent warning in 64bit arch due to string format,

### DIFF
--- a/NUI/Core/NUIRenderer.m
+++ b/NUI/Core/NUIRenderer.m
@@ -315,7 +315,7 @@ static NUIRenderer *instance = nil;
 + (void)registerObject:(NSObject*)object
 {
     if ([NUISettings autoUpdateIsEnabled] && object != nil) {
-        NSString *hash = [NSString stringWithFormat:@"%d", object.hash];
+        NSString *hash = [NSString stringWithFormat:@"%lu", (unsigned long)object.hash];
         NUIRenderer *instance = [self getInstance];
         if (![instance.renderedObjectIdentifiers containsObject:hash]) {
             [instance.renderedObjectIdentifiers addObject:hash];


### PR DESCRIPTION
When compiling for 64 bit platforms, I get a compiler warning for this format string. Xcode suggested this change, which fixes the warning.
