### PR TITLE
Based on cnstoll's change to fix text properties in iOS 7

### DIFF
--- a/Demo/NUIDemo.xcodeproj/project.pbxproj
+++ b/Demo/NUIDemo.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		89B940451671418100850A9A /* NUIViewRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NUIViewRenderer.m; sourceTree = "<group>"; };
 		89B940461671418100850A9A /* NUIStyle.nss */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = NUIStyle.nss; sourceTree = "<group>"; };
 		89B9404A1671418100850A9A /* NUIViewBackground.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = NUIViewBackground.png; sourceTree = "<group>"; };
+		99970C75184CE33300FAE5AE /* NUIOrientationObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NUIOrientationObserver.h; sourceTree = "<group>"; };
 		B51BC288169724A3004A38F8 /* UISwitch+NUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UISwitch+NUI.h"; sourceTree = "<group>"; };
 		B51BC289169724A3004A38F8 /* UISwitch+NUI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UISwitch+NUI.m"; sourceTree = "<group>"; };
 		B51BC28C16972527004A38F8 /* NUISwitchRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NUISwitchRenderer.h; sourceTree = "<group>"; };
@@ -329,6 +330,7 @@
 				4A744B18169904500068F3CF /* NUIFileMonitor.m */,
 				89B940271671418100850A9A /* NUIGraphics.h */,
 				89B940281671418100850A9A /* NUIGraphics.m */,
+				99970C75184CE33300FAE5AE /* NUIOrientationObserver.h */,
 				89B940291671418100850A9A /* NUIRenderer.h */,
 				89B9402A1671418100850A9A /* NUIRenderer.m */,
 				89B9402B1671418100850A9A /* NUISettings.h */,

--- a/NUI/Core/NUIOrientationObserver.h
+++ b/NUI/Core/NUIOrientationObserver.h
@@ -1,0 +1,15 @@
+//
+//  NUIOrientationObserver.h
+//  NUI
+//
+//  Created by Matthew Garden on 11/27/2013.
+//  Copyright (c) 2013 Tom Benner. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol NUIOrientationObserver <NSObject>
+
+- (void)orientationDidChange:(NSNotification*)notification;
+
+@end

--- a/NUI/Core/NUIRenderer.h
+++ b/NUI/Core/NUIRenderer.h
@@ -30,6 +30,7 @@
 #import "NUIViewRenderer.h"
 #import "NUIWindowRenderer.h"
 #import "UIView+NUI.h"
+#import "NUIOrientationObserver.h"
 
 @interface NUIRenderer : NSObject {
     NSMutableArray *renderedObjects;
@@ -105,7 +106,7 @@
 + (void)sizeDidChangeForTableView:(UITableView*)tableView;
 + (void)sizeDidChangeForTableViewCell:(UITableViewCell*)cell;
 
-+ (void)addOrientationDidChangeObserver:(id)observer;
-+ (void)removeOrientationDidChangeObserver:(id)observer;
++ (void)addOrientationDidChangeObserver:(id<NUIOrientationObserver>)observer;
++ (void)removeOrientationDidChangeObserver:(id<NUIOrientationObserver>)observer;
 
 @end

--- a/NUI/Core/NUIRenderer.m
+++ b/NUI/Core/NUIRenderer.m
@@ -303,12 +303,12 @@ static NUIRenderer *instance = nil;
     [NUITableViewRenderer sizeDidChange:tableView];
 }
 
-+ (void)addOrientationDidChangeObserver:(id)observer
++ (void)addOrientationDidChangeObserver:(id<NUIOrientationObserver>)observer
 {
     [[NSNotificationCenter defaultCenter] addObserver:observer selector:@selector(orientationDidChange:) name:UIDeviceOrientationDidChangeNotification object:nil];
 }
 
-+ (void)removeOrientationDidChangeObserver:(id)observer {
++ (void)removeOrientationDidChangeObserver:(id<NUIOrientationObserver>)observer {
     [[NSNotificationCenter defaultCenter] removeObserver:observer name:UIDeviceOrientationDidChangeNotification object:nil];
 }
 

--- a/NUI/Core/NUIUtilities.h
+++ b/NUI/Core/NUIUtilities.h
@@ -14,4 +14,16 @@
 + (NSDictionary*)titleTextAttributesForClass:(NSString*)className;
 + (NSDictionary*)titleTextAttributesForClass:(NSString*)className withSuffix:(NSString*) suffix;
 
++ (NSString *)textAttributeFontKey;
++ (NSString *)textAttributeTextColorKey;
+
++ (BOOL)iOSVersionIsAtLeastiOS7;
+
+// Deprecated in iOS 7
++ (NSString *)textAttributeTextShadowColorKey;
++ (NSString *)textAttributeTextShadowOffsetKey;
+
+// iOS 7 and later
++ (NSString *)textAttributeShadowKey;
+
 @end

--- a/NUI/Core/NUIUtilities.m
+++ b/NUI/Core/NUIUtilities.m
@@ -27,20 +27,42 @@
         fontSize = fontSize ? fontSize : [UIFont systemFontSize];
         UIFont *font = fontName ? [UIFont fontWithName:fontName size:fontSize] : [UIFont systemFontOfSize:fontSize];
 
-        [titleTextAttributes setObject:font forKey:UITextAttributeFont];
+        [titleTextAttributes setObject:font forKey:[self textAttributeFontKey]];
     }
 
     if ([NUISettings hasProperty:fontColorSelector withClass:className]) {
-        [titleTextAttributes setObject:[NUISettings getColor:fontColorSelector withClass:className] forKey:UITextAttributeTextColor];
+        [titleTextAttributes setObject:[NUISettings getColor:fontColorSelector withClass:className] forKey:[self textAttributeTextColorKey]];
     }
 
-    if ([NUISettings hasProperty:textShadowColorSelector withClass:className]) {
-        [titleTextAttributes setObject:[NUISettings getColor:textShadowColorSelector withClass:className] forKey:UITextAttributeTextShadowColor];
+    if ([self iOSVersionIsAtLeastiOS7]) {
+        NSShadow *shadow = [[NSShadow alloc] init];
+        BOOL containsShadow = NO;
+        
+        if ([NUISettings hasProperty:textShadowColorSelector withClass:className]) {
+            containsShadow = YES;
+            shadow.shadowColor = [NUISettings getColor:textShadowColorSelector withClass:className];
+        }
+        
+        if ([NUISettings hasProperty:textShadowOffsetSelector withClass:className]) {
+            containsShadow = YES;
+            UIOffset offset = [NUISettings getOffset:textShadowOffsetSelector withClass:className];
+            CGSize shadowOffset = CGSizeMake(offset.horizontal, offset.vertical);
+            shadow.shadowOffset = shadowOffset;
+        }
+        
+        if (containsShadow) {
+            [titleTextAttributes setObject:shadow forKey:NSShadowAttributeName];
+        }
+    } else {
+        if ([NUISettings hasProperty:textShadowColorSelector withClass:className]) {
+            [titleTextAttributes setObject:[NUISettings getColor:textShadowColorSelector withClass:className] forKey:[self textAttributeTextShadowColorKey]];
+        }
+        
+        if ([NUISettings hasProperty:textShadowOffsetSelector withClass:className]) {
+            [titleTextAttributes setObject:[NSValue valueWithUIOffset:[NUISettings getOffset:textShadowOffsetSelector withClass:className]] forKey:[self textAttributeTextShadowOffsetKey]];
+        }
     }
 
-    if ([NUISettings hasProperty:textShadowOffsetSelector withClass:className]) {
-        [titleTextAttributes setObject:[NSValue valueWithUIOffset:[NUISettings getOffset:textShadowOffsetSelector withClass:className]] forKey:UITextAttributeTextShadowOffset];
-    }
 
     return titleTextAttributes;
 }
@@ -58,5 +80,66 @@
     return selector;
 }
 
++ (NSString *)textAttributeFontKey
+{
+    if ([self iOSVersionIsAtLeastiOS7]) {
+        return NSFontAttributeName;
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        return UITextAttributeFont;
+#pragma clang diagnostic pop
+    }
+}
+
++ (NSString *)textAttributeTextColorKey
+{
+    if ([self iOSVersionIsAtLeastiOS7]) {
+        return NSForegroundColorAttributeName;
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        return UITextAttributeTextColor;
+#pragma clang diagnostic pop
+    }
+}
+
++ (NSString *)textAttributeTextShadowColorKey
+{
+    if ([self iOSVersionIsAtLeastiOS7]) {
+        return nil;
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        return UITextAttributeTextShadowColor;
+#pragma clang diagnostic pop
+    }
+}
+
++ (NSString *)textAttributeTextShadowOffsetKey
+{
+    if ([self iOSVersionIsAtLeastiOS7]) {
+        return nil;
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        return UITextAttributeTextShadowOffset;
+#pragma clang diagnostic pop
+    }
+}
+
++ (NSString *)textAttributeShadowKey
+{
+    if ([self iOSVersionIsAtLeastiOS7]) {
+        return NSShadowAttributeName;
+    } else {
+        return nil;
+    }
+}
+
++ (BOOL)iOSVersionIsAtLeastiOS7
+{
+    return (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1);
+}
 
 @end

--- a/NUI/Core/Renderers/NUISegmentedControlRenderer.m
+++ b/NUI/Core/Renderers/NUISegmentedControlRenderer.m
@@ -44,8 +44,13 @@
 
     // Set background tint color
     if ([NUISettings hasProperty:@"background-tint-color" withClass:className]) {
-        // UISegmentedControlStyleBar is necessary for setTintColor to take effect
-        control.segmentedControlStyle = UISegmentedControlStyleBar;
+        if (![NUIUtilities iOSVersionIsAtLeastiOS7]) {
+            // UISegmentedControlStyleBar is necessary for setTintColor to take effect
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            control.segmentedControlStyle = UISegmentedControlStyleBar;
+#pragma clang diagnostic pop
+        }
         [control setTintColor:[NUISettings getColor:@"background-tint-color" withClass:className]];
     }
 

--- a/NUI/UI/UINavigationBar+NUI.h
+++ b/NUI/UI/UINavigationBar+NUI.h
@@ -9,7 +9,8 @@
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "NUIRenderer.h"
+#import "NUIOrientationObserver.h"
 
-@interface UINavigationBar (NUI)
+@interface UINavigationBar (NUI) <NUIOrientationObserver>
 
 @end

--- a/NUI/UI/UITabBar+NUI.h
+++ b/NUI/UI/UITabBar+NUI.h
@@ -9,7 +9,8 @@
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "NUIRenderer.h"
+#import "NUIOrientationObserver.h"
 
-@interface UITabBar (NUI)
+@interface UITabBar (NUI) <NUIOrientationObserver>
 
 @end

--- a/NUI/UI/UITableView+NUI.h
+++ b/NUI/UI/UITableView+NUI.h
@@ -9,7 +9,8 @@
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "NUIRenderer.h"
+#import "NUIOrientationObserver.h"
 
-@interface UITableView (NUI)
+@interface UITableView (NUI) <NUIOrientationObserver>
 
 @end

--- a/NUI/UI/UITableViewCell+NUI.h
+++ b/NUI/UI/UITableViewCell+NUI.h
@@ -9,7 +9,8 @@
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "NUIRenderer.h"
+#import "NUIOrientationObserver.h"
 
-@interface UITableViewCell (NUI)
+@interface UITableViewCell (NUI) <NUIOrientationObserver>
 
 @end


### PR DESCRIPTION
https://github.com/mutualmobile/nui/commit/42f9c63165f6a43e34edb4d157b3387487cdf644

With the following modifications added:
- warnings for use of deprecated selectors is disabled selectively
- text color key is specified (without this the demo was crashing for me)
- a protocol is introduced for objects that observe orientation changes (this is to remove an unknown selector warning when setting up the observers)
