### PR TITLE
Add method to allow for loading of multiple stylesheets

### DIFF
--- a/NUI/Core/NUISettings.h
+++ b/NUI/Core/NUISettings.h
@@ -22,6 +22,7 @@
 
 + (void)init;
 + (void)initWithStylesheet:(NSString*)name;
++ (void)appendStylesheet:(NSString*)name;
 + (void)loadStylesheetByPath:(NSString*)path;
 + (BOOL)autoUpdateIsEnabled;
 + (NSString*)autoUpdatePath;

--- a/NUI/Core/NUISettings.m
+++ b/NUI/Core/NUISettings.m
@@ -26,6 +26,30 @@ static NUISettings *instance = nil;
     instance.styles = [parser getStylesFromFile:name];
 }
 
+
++ (void)appendStylesheet:(NSString *)name
+{
+    instance = [self getInstance];
+    NUIStyleParser *parser = [[NUIStyleParser alloc] init];
+    [instance appendStyles:[parser getStylesFromFile:name]];
+}
+
+- (void)appendStyles:(NSMutableDictionary*)newStyles
+{
+    for (NSString* key in newStyles) {
+        id style = newStyles[key];
+        if (![styles objectForKey:key]) {
+            styles[key] = style;
+            continue;
+        }
+    
+        for (NSString *propertyKey in style) {
+            id propertyValue = style[propertyKey];
+            styles[key][propertyKey] = propertyValue;
+        }
+    }
+}
+
 + (void)loadStylesheetByPath:(NSString*)path
 {
     instance = [self getInstance];


### PR DESCRIPTION
`appendStylesheet:` method allows user to add or override styles defined in the initial stylesheet. This allows you to do things like:

```
[NUISettings initWithStylesheet:@"Base"];
if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
    [NUISettings appendStylesheet:@"iOS6"];
}
```

where the styles defined in the `iOS6` stylesheet above will add to or override those specified in the `Base` stylesheet (assuming you had a `#define` for `SYSTEM_VERSION_LESS_THAN`).
