### PR TITLE
Fix Xcode "unrecognized selector" warning

### DIFF
--- a/NUI/UI/UINavigationBar+NUI.h
+++ b/NUI/UI/UINavigationBar+NUI.h
@@ -12,4 +12,6 @@
 
 @interface UINavigationBar (NUI)
 
+- (void)orientationDidChange:(NSNotification*)notification;
+
 @end

--- a/NUI/UI/UITabBar+NUI.h
+++ b/NUI/UI/UITabBar+NUI.h
@@ -12,4 +12,6 @@
 
 @interface UITabBar (NUI)
 
+- (void)orientationDidChange:(NSNotification*)notification;
+
 @end

--- a/NUI/UI/UITableView+NUI.h
+++ b/NUI/UI/UITableView+NUI.h
@@ -12,4 +12,6 @@
 
 @interface UITableView (NUI)
 
+- (void)orientationDidChange:(NSNotification*)notification;
+
 @end

--- a/NUI/UI/UITableViewCell+NUI.h
+++ b/NUI/UI/UITableViewCell+NUI.h
@@ -12,4 +12,6 @@
 
 @interface UITableViewCell (NUI)
 
+- (void)orientationDidChange:(NSNotification*)notification;
+
 @end


### PR DESCRIPTION
Without these changes, Xcode shows an "unrecognized selector" warning at line 308 of `addOrientationDidChangeObserver` in NUIRenderer.m.
