### PR TITLE
Fix #186: avoid iOS7 deprecation warnings

### DIFF
--- a/NUI/Core/NUIUtilities.m
+++ b/NUI/Core/NUIUtilities.m
@@ -13,35 +13,59 @@
 + (NSDictionary*)titleTextAttributesForClass:(NSString*)className withSuffix:(NSString*) suffix
 {
     NSMutableDictionary *titleTextAttributes = [NSMutableDictionary dictionary];
-
+    
     NSString *fontNameSelector = [NUIUtilities selector:@"font-name" withSuffix:suffix];
     NSString *fontSizeSelector = [NUIUtilities selector:@"font-size" withSuffix:suffix];
     NSString *fontColorSelector = [NUIUtilities selector:@"font-color" withSuffix:suffix];
     NSString *textShadowColorSelector = [NUIUtilities selector:@"text-shadow-color" withSuffix:suffix];
     NSString *textShadowOffsetSelector = [NUIUtilities selector:@"text-shadow-offset" withSuffix:suffix];
-
+    
     if ([NUISettings hasProperty:fontNameSelector withClass:className] || [NUISettings hasProperty:fontSizeSelector withClass:className]) {
         NSString *fontName = [NUISettings get:fontNameSelector withClass:className];
         float fontSize = [NUISettings getFloat:fontSizeSelector withClass:className];
-
+        
         fontSize = fontSize ? fontSize : [UIFont systemFontSize];
         UIFont *font = fontName ? [UIFont fontWithName:fontName size:fontSize] : [UIFont systemFontOfSize:fontSize];
-
+        
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+        [titleTextAttributes setObject:font forKey:NSFontAttributeName];
+#else
         [titleTextAttributes setObject:font forKey:UITextAttributeFont];
+#endif
     }
-
+    
     if ([NUISettings hasProperty:fontColorSelector withClass:className]) {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+        [titleTextAttributes setObject:[NUISettings getColor:fontColorSelector withClass:className] forKey:NSForegroundColorAttributeName];
+#else
         [titleTextAttributes setObject:[NUISettings getColor:fontColorSelector withClass:className] forKey:UITextAttributeTextColor];
+#endif
     }
-
+    
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+    if ([NUISettings hasProperty:textShadowColorSelector withClass:className] || [NUISettings hasProperty:textShadowOffsetSelector withClass:className]) {
+        NSShadow *shadow = [NSShadow new];
+        
+        if ([NUISettings hasProperty:textShadowColorSelector withClass:className]) {
+            shadow.shadowColor = [NUISettings getColor:textShadowColorSelector withClass:className];
+        }
+        
+        if ([NUISettings hasProperty:textShadowOffsetSelector withClass:className]) {
+            shadow.shadowOffset = [NUISettings getSize:textShadowOffsetSelector withClass:className];
+        }
+        
+        [titleTextAttributes setObject:shadow forKey:NSShadowAttributeName];
+    }
+#else
     if ([NUISettings hasProperty:textShadowColorSelector withClass:className]) {
         [titleTextAttributes setObject:[NUISettings getColor:textShadowColorSelector withClass:className] forKey:UITextAttributeTextShadowColor];
     }
-
+    
     if ([NUISettings hasProperty:textShadowOffsetSelector withClass:className]) {
         [titleTextAttributes setObject:[NSValue valueWithUIOffset:[NUISettings getOffset:textShadowOffsetSelector withClass:className]] forKey:UITextAttributeTextShadowOffset];
     }
-
+#endif
+    
     return titleTextAttributes;
 }
 

--- a/NUI/Core/Renderers/NUISegmentedControlRenderer.m
+++ b/NUI/Core/Renderers/NUISegmentedControlRenderer.m
@@ -20,10 +20,10 @@
             [control setBackgroundImage:[NUISettings getImage:@"background-image-selected" withClass:className] forState:UIControlStateSelected barMetrics:UIBarMetricsDefault];
         }
     } else if ([NUISettings hasProperty:@"background-color" withClass:className] ||
-        [NUISettings hasProperty:@"border-color" withClass:className]) {
+               [NUISettings hasProperty:@"border-color" withClass:className]) {
         CALayer *layer = [NUIGraphics roundedRectLayerWithClass:className];
         UIImage *normalImage = [NUIGraphics roundedRectImageWithClass:className layer:layer];
-
+        
         if ([NUISettings hasProperty:@"background-color-selected" withClass:className]) {
             [layer setBackgroundColor:[[NUISettings getColor:@"background-color-selected" withClass:className] CGColor]];
         }
@@ -34,27 +34,29 @@
             [control setDividerImage:[NUISettings getImageFromColor:@"border-color" withClass:className] forLeftSegmentState:UIControlStateNormal rightSegmentState:UIControlStateNormal barMetrics:UIBarMetricsDefault];
         }
     }
-
+    
     // Set divider image or divider color
     if ([NUISettings hasProperty:@"divider-image" withClass:className]) {
         [control setDividerImage:[NUISettings getImage:@"divider-image" withClass:className] forLeftSegmentState:UIControlStateNormal rightSegmentState:UIControlStateNormal barMetrics:UIBarMetricsDefault];
     } else if ([NUISettings hasProperty:@"divider-color" withClass:className]) {
         [control setDividerImage:[NUISettings getImageFromColor:@"divider-color" withClass:className] forLeftSegmentState:UIControlStateNormal rightSegmentState:UIControlStateNormal barMetrics:UIBarMetricsDefault];
     }
-
+    
     // Set background tint color
     if ([NUISettings hasProperty:@"background-tint-color" withClass:className]) {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 70000
         // UISegmentedControlStyleBar is necessary for setTintColor to take effect
         control.segmentedControlStyle = UISegmentedControlStyleBar;
+#endif
         [control setTintColor:[NUISettings getColor:@"background-tint-color" withClass:className]];
     }
-
+    
     NSDictionary *titleTextAttributes = [NUIUtilities titleTextAttributesForClass:className];
     
     if ([[titleTextAttributes allKeys] count] > 0) {
         [control setTitleTextAttributes:titleTextAttributes forState:UIControlStateNormal];
     }
-
+    
     NSDictionary *selectedSegmentAttributeOverrides = [NUIUtilities titleTextAttributesForClass:className withSuffix:@"selected"];
     if ([[selectedSegmentAttributeOverrides allKeys] count] > 0) {
         NSMutableDictionary *selectedTitleTextAttributes = [titleTextAttributes mutableCopy];


### PR DESCRIPTION
Fixes issue #186 by using conditional code against the deployment iOS target.
