### PR TITLE
Apply nuiClass change immediately

### DIFF
--- a/NUI/UI/UIBarButtonItem+NUI.m
+++ b/NUI/UI/UIBarButtonItem+NUI.m
@@ -46,6 +46,7 @@
 
 - (void)setNuiClass:(NSString*)value {
     objc_setAssociatedObject(self, kNUIAssociatedClassKey, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [self applyNUI];
 }
 
 - (NSString*)nuiClass {

--- a/NUI/UI/UINavigationItem+NUI.m
+++ b/NUI/UI/UINavigationItem+NUI.m
@@ -38,6 +38,7 @@
 
 - (void)setNuiClass:(NSString*)value {
     objc_setAssociatedObject(self, kNUIAssociatedClassKey, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [self applyNUI];
 }
 
 - (NSString*)nuiClass {

--- a/NUI/UI/UITabBarItem+NUI.m
+++ b/NUI/UI/UITabBarItem+NUI.m
@@ -38,6 +38,7 @@
 
 - (void)setNuiClass:(NSString*)value {
     objc_setAssociatedObject(self, kNUIAssociatedClassKey, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [self applyNUI];
 }
 
 - (NSString*)nuiClass {

--- a/NUI/UI/UIView+NUI.m
+++ b/NUI/UI/UIView+NUI.m
@@ -73,6 +73,7 @@
     }
     
     objc_setAssociatedObject(self, kNUIAssociatedClassKey, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [self applyNUI];
 }
 
 - (NSString*)nuiClass {


### PR DESCRIPTION
Changing nuiClass after a control is moved to a window currently has no effect. This commit fixes this issue.
