### PR TITLE
Reverts fix for applying a nuiClass when it has changed

### DIFF
--- a/NUI/UI/UIBarButtonItem+NUI.m
+++ b/NUI/UI/UIBarButtonItem+NUI.m
@@ -46,7 +46,6 @@
 
 - (void)setNuiClass:(NSString*)value {
     objc_setAssociatedObject(self, kNUIAssociatedClassKey, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    [self applyNUI];
 }
 
 - (NSString*)nuiClass {

--- a/NUI/UI/UINavigationItem+NUI.m
+++ b/NUI/UI/UINavigationItem+NUI.m
@@ -38,7 +38,6 @@
 
 - (void)setNuiClass:(NSString*)value {
     objc_setAssociatedObject(self, kNUIAssociatedClassKey, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    [self applyNUI];
 }
 
 - (NSString*)nuiClass {

--- a/NUI/UI/UITabBarItem+NUI.m
+++ b/NUI/UI/UITabBarItem+NUI.m
@@ -38,7 +38,6 @@
 
 - (void)setNuiClass:(NSString*)value {
     objc_setAssociatedObject(self, kNUIAssociatedClassKey, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    [self applyNUI];
 }
 
 - (NSString*)nuiClass {

--- a/NUI/UI/UIView+NUI.m
+++ b/NUI/UI/UIView+NUI.m
@@ -73,7 +73,6 @@
     }
     
     objc_setAssociatedObject(self, kNUIAssociatedClassKey, value, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    [self applyNUI];
 }
 
 - (NSString*)nuiClass {


### PR DESCRIPTION
The fix for applying a nuiClass when it has changed causes problems. It causes the styles to be applied right away instead of during didMoveToWindow. This could break many controls.

(This reverts commit 994166ea275669d773643455b1d6a322b2f2f9d3)
