### PR TITLE
Add setDebugColor to NUISettings.

### DIFF
--- a/Demo/NUIDemo/main.m
+++ b/Demo/NUIDemo/main.m
@@ -22,6 +22,9 @@ int main(int argc, char *argv[])
         // file at runtime
         //[NUISettings setAutoUpdatePath:@"/path/to/Style.nss"];
         
+        // To see which font and border colors are being set via NUI, uncomment this:
+        //[NUISettings setDebugColor:[UIColor greenColor]];
+        
         return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
     }
 }

--- a/NUI/Core/NUISettings.h
+++ b/NUI/Core/NUISettings.h
@@ -17,6 +17,10 @@
     NSString *stylesheetName;
     NSMutableArray *additionalStylesheetNames;
     NSString *stylesheetOrientation;
+    
+#ifdef DEBUG
+    UIColor* debugColor;
+#endif
 }
 
 @property(nonatomic,retain)NSString *autoUpdatePath;
@@ -25,6 +29,10 @@
 @property(nonatomic,retain)NSMutableArray *additionalStylesheetNames;
 @property(nonatomic,retain)NSMutableArray *globalExclusions;
 @property(nonatomic,retain)NSString* stylesheetOrientation;
+
+#ifdef DEBUG
+@property(nonatomic,retain)UIColor* debugColor;
+#endif
 
 + (void)init;
 + (void)initWithStylesheet:(NSString*)name;
@@ -53,6 +61,7 @@
 + (NSMutableArray*)getGlobalExclusions;
 + (void)setGlobalExclusions:(NSArray*)globalExclusions;
 + (NSString *)stylesheetOrientation;
++ (void)setDebugColor:(UIColor *)color;
 
 @end
 

--- a/NUI/Core/NUISettings.m
+++ b/NUI/Core/NUISettings.m
@@ -15,6 +15,10 @@
 @synthesize stylesheetName, additionalStylesheetNames;
 @synthesize stylesheetOrientation;
 
+#ifdef DEBUG
+@synthesize debugColor;
+#endif
+
 static NUISettings *instance = nil;
 
 + (void)init
@@ -186,7 +190,15 @@ static NUISettings *instance = nil;
 }
 
 + (UIColor*)getColor:(NSString*)property withClass:(NSString*)className
-{   
+{
+#ifdef DEBUG
+    instance = [self getInstance];
+    
+    if (instance.debugColor && [self shouldUseDebugColorForProperty:property]) {
+        return instance.debugColor;
+    }
+#endif
+    
     return [NUIConverter toColor:[self get:property withClass:className]];
 }
 
@@ -254,6 +266,29 @@ static NUISettings *instance = nil;
 + (NSString *)stylesheetOrientationFromInterfaceOrientation:(UIInterfaceOrientation)orientation
 {
     return UIInterfaceOrientationIsLandscape(orientation) ? @"landscape" : @"portrait";
+}
+
++ (void)setDebugColor:(UIColor *)color
+{
+#ifdef DEBUG
+    instance = [self getInstance];
+    instance.debugColor = color;
+#endif
+}
+
++ (BOOL)shouldUseDebugColorForProperty:(NSString*)property
+{
+    static NSArray *debugProperties;
+    
+    if (!debugProperties)
+        debugProperties = @[@"font-color", @"border-color"];
+    
+    for (NSString *debugProperty in debugProperties) {
+        if ([property hasPrefix:debugProperty])
+            return YES;
+    }
+    
+    return NO;
 }
 
 + (NUISettings*)getInstance


### PR DESCRIPTION
Let's you quickly see which controls are being styled via NUI, so you can see if you missed any.
