### PR TITLE
Fix gradient rendering code so re-rendering works without crashing

### DIFF
--- a/NUI/Core/NUIConstants.h
+++ b/NUI/Core/NUIConstants.h
@@ -14,4 +14,4 @@ static NSString * const kNUIClassNone               = @"none";
 
 static void * const kNUIAssociatedClassKey          = "nuiClass";
 static void * const kNUIAssociatedAppliedFlagKey    = "nuiIsApplied";
-
+static void * const kNUIAssociatedGradientLayerKey  = "nuiGradientLayer";

--- a/NUI/Core/Renderers/NUIBarButtonItemRenderer.m
+++ b/NUI/Core/Renderers/NUIBarButtonItemRenderer.m
@@ -7,6 +7,7 @@
 //
 
 #import "NUIBarButtonItemRenderer.h"
+#import "UIBarButtonItem+NUI.h"
 
 @implementation NUIBarButtonItemRenderer
 
@@ -28,11 +29,15 @@
                                               gradientLayerWithTop:[NUISettings getColor:@"background-color-top" withClass:className]
                                               bottom:[NUISettings getColor:@"background-color-bottom" withClass:className]
                                               frame:layer.frame];
-            int backgroundLayerIndex = 0;
-            if (item.isNUIApplied) {
-                [[layer.sublayers objectAtIndex:backgroundLayerIndex] removeFromSuperlayer];
+            
+            if (item.gradientLayer) {
+                [layer replaceSublayer:item.gradientLayer with:gradientLayer];
+            } else {
+                int backgroundLayerIndex = 0;
+                [layer insertSublayer:gradientLayer atIndex:backgroundLayerIndex];
             }
-            [layer insertSublayer:gradientLayer atIndex:backgroundLayerIndex];
+            
+            item.gradientLayer = gradientLayer;
         }
         
         if ([NUISettings hasProperty:@"background-color" withClass:className]) {

--- a/NUI/Core/Renderers/NUIButtonRenderer.m
+++ b/NUI/Core/Renderers/NUIButtonRenderer.m
@@ -8,6 +8,7 @@
 
 #import "NUIButtonRenderer.h"
 #import "NUIViewRenderer.h"
+#import "UIButton+NUI.h"
 
 @implementation NUIButtonRenderer
 
@@ -55,11 +56,15 @@
                                           gradientLayerWithTop:[NUISettings getColor:@"background-color-top" withClass:className]
                                           bottom:[NUISettings getColor:@"background-color-bottom" withClass:className]
                                           frame:button.bounds];
-        int backgroundLayerIndex = [button.layer.sublayers count] == 1 ? 0 : 1;
-        if (button.isNUIApplied) {
-            [[button.layer.sublayers objectAtIndex:backgroundLayerIndex] removeFromSuperlayer];
+        
+        if (button.gradientLayer) {
+            [button.layer replaceSublayer:button.gradientLayer with:gradientLayer];
+        } else {
+            int backgroundLayerIndex = [button.layer.sublayers count] == 1 ? 0 : 1;
+            [button.layer insertSublayer:gradientLayer atIndex:backgroundLayerIndex];
         }
-        [button.layer insertSublayer:gradientLayer atIndex:backgroundLayerIndex];
+        
+        button.gradientLayer = gradientLayer;
     }
     
     // Set background image

--- a/NUI/UI/UIBarButtonItem+NUI.h
+++ b/NUI/UI/UIBarButtonItem+NUI.h
@@ -14,6 +14,7 @@
 
 @property (nonatomic, retain) NSString* nuiClass;
 @property (nonatomic, assign, getter = isNUIApplied) BOOL nuiApplied;
+@property (nonatomic, retain) CALayer* gradientLayer;
 
 - (void)applyNUI;
 

--- a/NUI/UI/UIBarButtonItem+NUI.m
+++ b/NUI/UI/UIBarButtonItem+NUI.m
@@ -49,4 +49,14 @@
     return [nuiAppliedFlagNumber boolValue];
 }
 
+- (void)setGradientLayer:(CALayer *)gradientLayer
+{
+    objc_setAssociatedObject(self, kNUIAssociatedGradientLayerKey, gradientLayer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (CALayer *)gradientLayer
+{
+    return objc_getAssociatedObject(self, kNUIAssociatedGradientLayerKey);
+}
+
 @end

--- a/NUI/UI/UIButton+NUI.h
+++ b/NUI/UI/UIButton+NUI.h
@@ -11,5 +11,6 @@
 #import "NUIRenderer.h"
 
 @interface UIButton (NUI)
-
+@property (nonatomic, retain) CALayer* gradientLayer;
 @end
+

--- a/NUI/UI/UIButton+NUI.m
+++ b/NUI/UI/UIButton+NUI.m
@@ -101,4 +101,14 @@
     [self override_setAttributedTitle:transformedTitle forState:state];
 }
 
+- (void)setGradientLayer:(CALayer *)gradientLayer
+{
+    objc_setAssociatedObject(self, kNUIAssociatedGradientLayerKey, gradientLayer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (CALayer *)gradientLayer
+{
+    return objc_getAssociatedObject(self, kNUIAssociatedGradientLayerKey);
+}
+
 @end


### PR DESCRIPTION
The current code guesses which layer needs to be replaced and is sometimes incorrect. This pull request stores the gradient layer in a property to avoid this issue.

The crash would happen under iOS 7.x whenever a stylesheet change caused a re-render and there was at least one control using a gradient layer.
