### PR TITLE
add alpha support for hex representation of color

### DIFF
--- a/NUI/Core/NUIConverter.m
+++ b/NUI/Core/NUIConverter.m
@@ -144,7 +144,7 @@
                 [UIColor colorWithRed:(float)((c >> 16) & 0xFF) / 255.0f
                                 green:(float)((c >>  8) & 0xFF) / 255.0f
                                  blue:(float)((c >>  0) & 0xFF) / 255.0f
-                                alpha:1.f]
+                                alpha:1.0f]
                :[UIColor colorWithRed:(float)((c >> 24) & 0xFF) / 255.0f
                                 green:(float)((c >> 16) & 0xFF) / 255.0f
                                  blue:(float)((c >>  8) & 0xFF) / 255.0f


### PR DESCRIPTION
I added alpha support for hex color parsing as described in http://dev.w3.org/csswg/css-color/#hex-notation...I'm wondering if it's necessary to cache color/font already parsed so we can reduce the processing time?
