### PR TITLE
Provide a way to not repeat background-image

### DIFF
--- a/NUI/Core/Renderers/NUIViewRenderer.m
+++ b/NUI/Core/Renderers/NUIViewRenderer.m
@@ -13,12 +13,13 @@
 + (void)render:(UIView*)view withClass:(NSString*)className
 {
     if ([NUISettings hasProperty:@"background-image" withClass:className]) {
-        UIImage *image = [NUISettings getImage:@"background-image" withClass:className];
-        view.layer.contents = (id)image.CGImage;
+        if ([NUISettings hasProperty:@"background-repeat" withClass:className] && ![NUISettings getBoolean:@"background-repeat" withClass:className]) {
+            view.layer.contents = (__bridge id)[NUISettings getImage:@"background-image" withClass:className].CGImage;
+        } else {
+            [view setBackgroundColor: [NUISettings getColorFromImage:@"background-image" withClass: className]];
+        }
     } else if ([NUISettings hasProperty:@"background-color" withClass:className]) {
         [view setBackgroundColor: [NUISettings getColor:@"background-color" withClass: className]];
-    } else if ([NUISettings hasProperty:@"background-image-pattern" withClass:className]) {
-        [view setBackgroundColor: [NUISettings getColorFromImage:@"background-image-pattern" withClass: className]];
     }
 
     [self renderSize:view withClass:className];


### PR DESCRIPTION
colorWithPatternImage is highly memory consuming, I changed the code by setting the 'contents' property of CALayer directly, and added a new property called "background-image-pattern" for the original usage.
