### PR TITLE
Clipped uibutton text fix (#266)

### DIFF
--- a/NUI/Core/Renderers/NUIButtonRenderer.m
+++ b/NUI/Core/Renderers/NUIButtonRenderer.m
@@ -166,12 +166,16 @@
     
     [NUIViewRenderer renderBorder:button withClass:className];
     
-    // We need to apply the corner radius to all sublayers so that the shadow displays correctly
-    if ([NUISettings hasProperty:@"corner-radius" withClass:className]) {
+    // If a shadow-* is configured and corner-radius is set disable mask to bounds and fall back to manually applying corner radius to all sub-views (except the label)
+    if ([NUIViewRenderer hasShadowProperties:button withClass:className] &&
+        [NUISettings hasProperty:@"corner-radius" withClass:className]) {
         CGFloat r = [NUISettings getFloat:@"corner-radius" withClass:className];
-        for (CALayer* layer in button.layer.sublayers) {
-            layer.cornerRadius = r;
+        for (UIView* subview in button.subviews) {
+            if ([subview isKindOfClass:[UILabel class]] == NO) {
+                subview.layer.cornerRadius = r;
+            }
         }
+        button.layer.masksToBounds = NO;
     }
     
     [NUIViewRenderer renderShadow:button withClass:className];

--- a/NUI/Core/Renderers/NUIViewRenderer.h
+++ b/NUI/Core/Renderers/NUIViewRenderer.h
@@ -17,4 +17,6 @@
 + (void)renderShadow:(UIView*)view withClass:(NSString*)className;
 + (void)renderSize:(UIView*)view withClass:(NSString*)className;
 
++ (BOOL)hasShadowProperties:(UIView*)view withClass:(NSString*)className;
+
 @end

--- a/NUI/Core/Renderers/NUIViewRenderer.m
+++ b/NUI/Core/Renderers/NUIViewRenderer.m
@@ -41,6 +41,7 @@
     
     if ([NUISettings hasProperty:@"corner-radius" withClass:className]) {
         [layer setCornerRadius:[NUISettings getFloat:@"corner-radius" withClass:className]];
+        layer.masksToBounds = YES;
     }
 }
 
@@ -80,6 +81,15 @@
     if (height != view.frame.size.height || width != view.frame.size.width) {
         view.frame = CGRectMake(view.frame.origin.x, view.frame.origin.y, width, height);
     }
+}
+
++ (BOOL)hasShadowProperties:(UIView*)view withClass:(NSString*)className {
+    
+    BOOL hasAnyShadowProperty = NO;
+    for (NSString *property in @[@"shadow-radius", @"shadow-offset", @"shadow-color", @"shadow-opacity"]) {
+        hasAnyShadowProperty |= [NUISettings hasProperty:property withClass:className];
+    }
+    return hasAnyShadowProperty;
 }
 
 @end


### PR DESCRIPTION
When both a shadow-\* and corner-radius is present in a style class, the corner radius is not applied to any UILabel sub-views to avoid 'clipping' (whilst retaining button.label.maskToBounds = NO). 

However if there are no shadow-\* properties in the style, this patch sets maskToBounds = YES instead and avoids applying corner-radius on the sub-layers. 

Using maskToBounds = YES in this case avoid #267 (but doesn't fix it for the shadow case), hence why both of these approaches are implemented here. 
