### PR TITLE
fix the crash lead by the NUIBarButtonItemRenderer bug

### DIFF
--- a/NUI/Core/Renderers/NUIBarButtonItemRenderer.m
+++ b/NUI/Core/Renderers/NUIBarButtonItemRenderer.m
@@ -30,13 +30,8 @@
                                               bottom:[NUISettings getColor:@"background-color-bottom" withClass:className]
                                               frame:layer.frame];
             
-            if (item.gradientLayer) {
-                [layer replaceSublayer:item.gradientLayer with:gradientLayer];
-            } else {
-                int backgroundLayerIndex = 0;
-                [layer insertSublayer:gradientLayer atIndex:backgroundLayerIndex];
-            }
-            
+            int backgroundLayerIndex = 0;
+            [layer insertSublayer:gradientLayer atIndex:backgroundLayerIndex];
             item.gradientLayer = gradientLayer;
         }
         


### PR DESCRIPTION
Rendering the UIBarButton twice would lead to a crash " Exception: replaced layer CAGradientLayer: 0x17ece3f0 is not a sublayer of CALayer: 0x19068570".

After investigation, I found that the issue is in the line 35:
`[layer insertSublayer:gradientLayer atIndex:backgroundLayerIndex];` 
It's trying to replace a sublayer of the `layer`, which is newly generated at line 23: `CALayer *layer = [CALayer layer];`, which doesn't have any sublayer. That leads to the crash.
