### PR TITLE
Cast the call to objc_msgSend to the correct type.

### DIFF
--- a/NUI/Core/NUIConverter.m
+++ b/NUI/Core/NUIConverter.m
@@ -120,7 +120,7 @@
         if ([[UIColor class] respondsToSelector:selector]) {
             // [[UIColor class] performSelector:selector] would be better here, but it causes
             // a warning: "PerformSelector may cause a leak because its selector is unknown"
-            return objc_msgSend([UIColor class], selector);
+            return ((UIColor* (*)(id, SEL))objc_msgSend)([UIColor class], selector);
         }
     }
     


### PR DESCRIPTION
Apparently, the last update to LLVM made it necesary to cast objc_msgSend to the desired type before using it.  This is causing NUI to fail to compile in the latest beta version of CocoaPods with XCode 6.

see: https://github.com/CocoaPods/CocoaPods/issues/3060