### PR TITLE
Fixing  objc_msgSend([UIColor class], selector); issue with Cocoapods 0.36

### DIFF
--- a/NUI/Core/NUIConverter.m
+++ b/NUI/Core/NUIConverter.m
@@ -120,7 +120,9 @@
         if ([[UIColor class] respondsToSelector:selector]) {
             // [[UIColor class] performSelector:selector] would be better here, but it causes
             // a warning: "PerformSelector may cause a leak because its selector is unknown"
-            return objc_msgSend([UIColor class], selector);
+            id (*typed_msgSend)(id, SEL) = (void *)objc_msgSend;
+            // objc_msgSend([UIColor class], selector); cause error: too many arguments to function call, expected 0, have 2
+            return typed_msgSend([UIColor class], selector);
         }
     }
     


### PR DESCRIPTION
We started to the following compile issue with NUI when we updated to Cocoapods 0.36. 
```error: too many arguments to function call, expected 0, have 2```

We were able to work around this issue by casting objc_msgSend to a specific function pointer type as described here: http://stackoverflow.com/questions/25852079/in-xcode6-gold-master-using-objc-msgsend-now-throws-a-syntax-error-saying-the-n