### PR TITLE
Use framework imports where available [Fix `use_frameworks!`]

### DIFF
--- a/NUI/Core/NUIStyleParser.m
+++ b/NUI/Core/NUIStyleParser.m
@@ -7,7 +7,13 @@
 //
 
 #import "NUIStyleParser.h"
-#import "NUIParse.h"
+
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
+
 #import "NUIPTokeniser.h"
 #import "NUITokeniserDelegate.h"
 #import "NUIParserDelegate.h"

--- a/NUI/Core/Parser/NUIDeclaration.h
+++ b/NUI/Core/Parser/NUIDeclaration.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 //
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @interface NUIDeclaration : NSObject<NUIPParseResult>
 

--- a/NUI/Core/Parser/NUIDefinition.h
+++ b/NUI/Core/Parser/NUIDefinition.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 //
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @interface NUIDefinition : NSObject<NUIPParseResult>
 

--- a/NUI/Core/Parser/NUIMediaBlock.h
+++ b/NUI/Core/Parser/NUIMediaBlock.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 //
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @interface NUIMediaBlock : NSObject<NUIPParseResult>
 

--- a/NUI/Core/Parser/NUIMediaOptionSet.h
+++ b/NUI/Core/Parser/NUIMediaOptionSet.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 //
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @interface NUIMediaOption : NSObject<NUIPParseResult>
 

--- a/NUI/Core/Parser/NUIParserDelegate.h
+++ b/NUI/Core/Parser/NUIParserDelegate.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 //
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @interface NUIParserDelegate : NSObject <NUIPParserDelegate>
 

--- a/NUI/Core/Parser/NUIRuleSet.h
+++ b/NUI/Core/Parser/NUIRuleSet.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 //
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @interface NUIRuleSet : NSObject<NUIPParseResult>
 

--- a/NUI/Core/Parser/NUISelectorSet.h
+++ b/NUI/Core/Parser/NUISelectorSet.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 //
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @interface NUISelectorSet : NSObject<NUIPParseResult>
 

--- a/NUI/Core/Parser/NUIStyleSheet.h
+++ b/NUI/Core/Parser/NUIStyleSheet.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 //
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @interface NUIStyleSheet : NSObject <NUIPParseResult>
 

--- a/NUI/Core/Parser/NUIStyleSheetItem.h
+++ b/NUI/Core/Parser/NUIStyleSheetItem.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 //
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @class NUIRuleSet, NUIDefinition, NUIMediaBlock;
 

--- a/NUI/Core/Parser/NUITokeniserDelegate.h
+++ b/NUI/Core/Parser/NUITokeniserDelegate.h
@@ -6,7 +6,11 @@
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 //
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @interface NUITokeniserDelegate : NSObject <NUIPTokeniserDelegate>
 

--- a/NUI/Core/Parser/NUIVariableToken.h
+++ b/NUI/Core/Parser/NUIVariableToken.h
@@ -5,7 +5,11 @@
 //  Created by Tony Mann on 1/14/14.
 //  Copyright (c) 2014 Tom Benner. All rights reserved.
 
-#import "NUIParse.h"
+#if __has_include(<NUIParse/NUIParse.h>)
+#    import <NUIParse/NUIParse.h>
+#else
+#    import "NUIParse.h"
+#endif
 
 @interface NUIVariableToken : NUIPToken
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Installation
 ### CocoaPods
 
 NUI is most easily installed using [CocoaPods](http://cocoapods.org/). Its pod name is "NUI". After installing it, add `[NUISettings init];` to `application:didFinishLaunchingWithOptions` in AppDelegate.m (like [this](https://github.com/tombenner/nui/blob/master/Demo/NUIDemo/AppDelegate.m)).
+When installed as a framework, NUI can be natively imported in Swift. Just add
+`import NUI` to the top of your file.
 
 ### Without CocoaPods
 
@@ -76,18 +78,11 @@ If you choose not to use CocoaPods, you can install NUI with these steps:
 
 1. Copy the NUI directory into your application
 2. Add the CoreImage and QuartzCore frameworks to your application if you haven't already (like [this](http://stackoverflow.com/a/3377682))
-3. Add [CoreParse](https://github.com/beelsebob/CoreParse) as a subproject, set its iOSCoreParse target as a dependency of your target, and add libCoreParse.a to your linked libraries.
+3. Add [NUIParse](https://github.com/tombenner/NUIParse) as a subproject, set its iOSNUIParse target as a dependency of your target, and add libNUIParse.a to your linked libraries.
 4. Add `[NUISettings init];` to `application:didFinishLaunchingWithOptions` in AppDelegate.m (like [this](https://github.com/tombenner/nui/blob/master/Demo/NUIDemo/AppDelegate.m))
+5. To use NUI in Swift add `#import <NUI/NUISettings.h>` to your bridging header.
 
 The Demo uses CocoaPods, so you'll want to [install CocoaPods](http://cocoapods.org/), run `pod install` in the `Demo` directory, and then open the .xcworkspace to open the project.
-
-### Swift
-
-If you're using Swift, in addition to the steps above, you'll also want to add the following `#import` in your bridging header:
-
-```objective-c
-#import <NUI/NUISettings.h>
-```
 
 Usage
 -----


### PR DESCRIPTION
When using the new `use_frameworks!` option in Cocoapods, by default errors
about non-module imports are thrown, whenever a header is imported with "" that
does not belong to the same module (same target)

To circumvent this, import dependencies using </> when possible

This is one of the two changes, that fixed #303 for me. I have been using this off my own fork for about 5 months now.
The other part is sitting in the [NUIParse#2](https://github.com/tombenner/NUIParse/pull/2) from roughly around the same time, that I originally made this commit.

The second part might be optional for Objective-C only projects, but is definitely needed for Swift projects, that use the native import syntax (and not a bridging header).

If @tombenner or anybody else with push access to NUIParse is looking at this, please also have a look at [NUIParse#2](https://github.com/tombenner/NUIParse/pull/2).