### PR TITLE
Making nuiClass property of UIView IBInspectable

### DIFF
--- a/NUI/UI/UIView+NUI.h
+++ b/NUI/UI/UIView+NUI.h
@@ -12,7 +12,7 @@
 
 @interface UIView (NUI)
 
-@property (nonatomic, retain) NSString* nuiClass;
+@property (nonatomic, retain) IBInspectable NSString* nuiClass;
 @property (nonatomic, assign, getter = isNUIApplied) BOOL nuiApplied;
 
 - (void)applyNUI;


### PR DESCRIPTION
This amend adds an nuiClass attribute in the Attribute Inspector on all UIViews in Interface Builder.
This simplifies setting nuiClass runtime attributes on UIViews when using NUI in Storyboards and XIBs.

![screen shot 2016-01-06 at 12 37 42](https://cloud.githubusercontent.com/assets/6560960/12142743/7845e08a-b472-11e5-8a6d-1d780cb500cf.png) ![screen shot 2016-01-06 at 12 35 39](https://cloud.githubusercontent.com/assets/6560960/12142706/2e47facc-b472-11e5-885e-0f00c085b2dc.png)
