### PR TITLE
UITextField different textRect for editing and static text. #344

### DIFF
--- a/NUI/UI/UITextField+NUI.m
+++ b/NUI/UI/UITextField+NUI.m
@@ -59,7 +59,7 @@
 }
 
 - (CGRect)override_editingRectForBounds:(CGRect)bounds {
-    return [self textRectForBounds:bounds];
+    return [self override_editingRectForBounds:bounds];
 }
 
 @end


### PR DESCRIPTION
UITextField+NUI.m fix override_editingRectForBounds method.
