### PR TITLE
Resolves Test Failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'cocoapods', '0.39.0'
+gem 'cocoapods', '1.1.1'


### PR DESCRIPTION
Resolves "The `master` repo requires CocoaPods 1.0.0 - (currently using 0.39.0)" error.